### PR TITLE
Update vapoursynth-zig

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "1.0.1",
     .dependencies = .{
         .vapoursynth = .{
-            .url = "git+https://github.com/dnjulek/vapoursynth-zig.git#f387003fb2dbdeb2e50b8b4530e9485d4098b2c5",
-            .hash = "122039953584f904643a2cfed6c6bcb8e4553044cd8dd5a02bee3248104c38daf600",
+            .url = "git+https://github.com/dnjulek/vapoursynth-zig.git#2a3af1ae3d3d544bfbb90b8f61bb3a1ceacad9d6",
+            .hash = "12204517c4184153bd49e4f19bc38a7604bd2d4f840f43ac55f569b6f8bf5b8413d0",
         },
         .set_version = .{
             .url = "git+https://github.com/ritalin/zig-set-version.git#db61db987b1bd6ec4a4fe867999aea6c7b228fdf",

--- a/src/plugin_functions/expand_analysis_data.zig
+++ b/src/plugin_functions/expand_analysis_data.zig
@@ -21,61 +21,65 @@ export fn getFrameExpandAnalysisData(n: c_int, activation_reason: vs.ActivationR
     if (activation_reason == .Initial) {
         vsapi.?.requestFrameFilter.?(n, d.node, frame_ctx);
     } else if (activation_reason == .AllFramesReady) {
-        var src = zapi.Frame.init(d.node, n, frame_ctx, core, vsapi);
-        const props = src.getPropertiesRW();
+        var src = zapi.ZFrame.init(d.node, n, frame_ctx, core, vsapi);
+        var dst = src.copyFrame();
+        defer src.deinit();
 
-        const analysis_data = vsutil.getDataProp(vsapi, props, "MVTools_MVAnalysisData") catch {
+        const src_props = src.getProperties();
+        const dst_props = dst.getProperties();
+
+        const analysis_data = src_props.getData("MVTools_MVAnalysisData", 0) orelse {
             vsapi.?.setFilterError.?("Could not read MVTools_MVAnalysisData property.", frame_ctx);
-            src.deinit();
+            dst.deinit();
             return null;
         };
         std.debug.assert(analysis_data.len == 21 * comptime @sizeOf(u32));
 
         var position: u32 = 0;
         const magic_key, position = util.readInt(u32, analysis_data, position); // (uninitialized)
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_MagicKey", magic_key, .Replace);
+        dst_props.setInt("Analysis_MagicKey", magic_key, .Replace);
         const version, position = util.readInt(u32, analysis_data, position); // (uninitialized)
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_Version", version, .Replace);
+        dst_props.setInt("Analysis_Version", version, .Replace);
         const block_size_x, position = util.readInt(u32, analysis_data, position);
         const block_size_y, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_BlockSize", block_size_x, .Replace);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_BlockSize", block_size_y, .Append);
+        dst_props.setInt("Analysis_BlockSize", block_size_x, .Replace);
+        dst_props.setInt("Analysis_BlockSize", block_size_y, .Append);
         const pel, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_Pel", pel, .Replace);
+        dst_props.setInt("Analysis_Pel", pel, .Replace);
         const level_count, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_LevelCount", level_count, .Replace);
+        dst_props.setInt("Analysis_LevelCount", level_count, .Replace);
         const delta_frame, position = util.readInt(i32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_DeltaFrame", delta_frame, .Replace);
+        dst_props.setInt("Analysis_DeltaFrame", delta_frame, .Replace);
         const backwards, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_Backwards", backwards, .Replace);
+        dst_props.setInt("Analysis_Backwards", backwards, .Replace);
         const cpu_flags, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_CpuFlags", cpu_flags, .Replace);
+        dst_props.setInt("Analysis_CpuFlags", cpu_flags, .Replace);
         const motion_flags, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_MotionFlags", motion_flags, .Replace);
+        dst_props.setInt("Analysis_MotionFlags", motion_flags, .Replace);
         const width, position = util.readInt(u32, analysis_data, position);
         const height, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_FrameSize", width, .Replace);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_FrameSize", height, .Append);
+        dst_props.setInt("Analysis_FrameSize", width, .Replace);
+        dst_props.setInt("Analysis_FrameSize", height, .Append);
         const overlap_x, position = util.readInt(u32, analysis_data, position);
         const overlap_y, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_Overlap", overlap_x, .Replace);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_Overlap", overlap_y, .Append);
+        dst_props.setInt("Analysis_Overlap", overlap_x, .Replace);
+        dst_props.setInt("Analysis_Overlap", overlap_y, .Append);
         const block_count_x, position = util.readInt(u32, analysis_data, position);
         const block_count_y, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_BlockCount", block_count_x, .Replace);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_BlockCount", block_count_y, .Append);
+        dst_props.setInt("Analysis_BlockCount", block_count_x, .Replace);
+        dst_props.setInt("Analysis_BlockCount", block_count_y, .Append);
         const bits_per_sample, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_BitsPerSample", bits_per_sample, .Replace);
+        dst_props.setInt("Analysis_BitsPerSample", bits_per_sample, .Replace);
         const chroma_ratio_y, position = util.readInt(u32, analysis_data, position);
         const chroma_ratio_x, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_ChromaRatio", chroma_ratio_x, .Replace);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_ChromaRatio", chroma_ratio_y, .Append);
+        dst_props.setInt("Analysis_ChromaRatio", chroma_ratio_x, .Replace);
+        dst_props.setInt("Analysis_ChromaRatio", chroma_ratio_y, .Append);
         const padding_x, position = util.readInt(u32, analysis_data, position);
         const padding_y, position = util.readInt(u32, analysis_data, position);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_Padding", padding_x, .Replace);
-        _ = vsapi.?.mapSetInt.?(props, "Analysis_Padding", padding_y, .Append);
+        dst_props.setInt("Analysis_Padding", padding_x, .Replace);
+        dst_props.setInt("Analysis_Padding", padding_y, .Append);
 
-        return src.frame;
+        return dst.frame;
     }
     return null;
 }
@@ -90,9 +94,9 @@ export fn freeExpandAnalysisData(instance_data: ?*anyopaque, core: ?*vs.Core, vs
 pub export fn createExpandAnalysisData(in: ?*const vs.Map, out: ?*vs.Map, user_data: ?*anyopaque, core: ?*vs.Core, vsapi: ?*const vs.API) callconv(.C) void {
     _ = user_data;
     var d: FunctionData = undefined;
-    var map = zapi.Map.init(in, out, vsapi);
+    var map_in = zapi.ZMap.init(in, vsapi);
 
-    d.node, d.vi = map.getNodeVi("clip");
+    d.node, d.vi = map_in.getNodeVi("clip");
 
     const data: *FunctionData = allocator.create(FunctionData) catch unreachable;
     data.* = d;


### PR DESCRIPTION
Changes:
- Correct implementation of ``ZMap`` with all methods (getData/setData/getInt/etc).
- You can't ``set*`` prop in src Frame (a bug in zigapi allowed this, fixed now),
you can only use ``set*`` if the input isn't ``const`` ([PlaneStats example](https://github.com/vapoursynth/vapoursynth/blob/a8c8b55ee426217a795436fc6c1f2da21efaefd8/src/core/simplefilters.cpp#L1932)).
- You need to init ``out: ?*vs.Map`` and ``in: ?*const vs.Map`` separately now.
init ``out`` only if you want to ``setError`` ([example](https://github.com/dnjulek/vapoursynth-zig/blob/2a3af1ae3d3d544bfbb90b8f61bb3a1ceacad9d6/examples/example-zigapi/src/invert_example.zig#L73-L74)).